### PR TITLE
Some fixes to the native test-console project

### DIFF
--- a/tests/test-console/test-console.cpp
+++ b/tests/test-console/test-console.cpp
@@ -46,8 +46,12 @@ int main(int argc, char* argv[])
 				std::cout << "Renamed: ";
 				break;
 			}
-
-			std::cout << evt.fileA << std::endl;
+			std::cout << evt.fileA;
+			if (evt.fileB)
+			{
+				std::cout << " -> " << evt.fileB;
+			}
+			std::cout << std::endl;
 		}
 
 		std::cout << "Press any key or 'q' to quit: ";

--- a/tests/test-console/test-console.vcxproj
+++ b/tests/test-console/test-console.vcxproj
@@ -88,22 +88,22 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <LinkIncremental>true</LinkIncremental>
-    <OutDir>$(SolutionDir)build\win\$(Configuration)\$(PlatformTarget)\</OutDir>
+    <OutDir>$(SolutionDir)build\win\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>obj\$(PlatformTarget)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
-    <OutDir>$(SolutionDir)build\win\$(Configuration)\$(PlatformTarget)\</OutDir>
+    <OutDir>$(SolutionDir)build\win\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>obj\$(PlatformTarget)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(SolutionDir)build\win\$(Configuration)\$(PlatformTarget)\</OutDir>
+    <OutDir>$(SolutionDir)build\win\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>obj\$(PlatformTarget)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <LinkIncremental>false</LinkIncremental>
-    <OutDir>$(SolutionDir)build\win\$(Configuration)\$(PlatformTarget)\</OutDir>
+    <OutDir>$(SolutionDir)build\win\$(PlatformTarget)\$(Configuration)\</OutDir>
     <IntDir>obj\$(PlatformTarget)\$(Configuration)\</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">


### PR DESCRIPTION
The build directory that the test-console project is building into doesn't match what the other projects have, fixed that. Also it's useful if the rename event shows the name of the file that it's being renamed to.