### PR TITLE
Fix linking of ALL THE THINGS

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 function usage() {
 	echo "Usage:"
-	echo "  build.sh -os [mac,linux] -arch [(space separated list of architectures, eg "i386 i586 x86_46")] [-autogen] [-configure] [-nobuild]"
+	echo "  build.sh -os [mac,linux] -arch [(space separated list of architectures, eg "i386 i586 x86_64")] [-autogen] [-configure] [-nobuild]"
 	exit
 }
 
@@ -86,7 +86,7 @@ if [ x"$OS" == x"mac" ]; then
 	cp ../m4/libtool.m4 .
 	patch -f<libtool.patch && cp libtool.m4 ../m4/ || true
 	popd
-	sdkpath="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.12.sdk"
+	sdkpath="/Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX.sdk"
 	sdkversion="10.9"
 	cflags="$cflags -isysroot $sdkpath -mmacosx-version-min=$sdkversion"
 	cxxflags="$cppflags -stdlib=libc++ -isysroot $sdkpath -mmacosx-version-min=$sdkversion"
@@ -123,6 +123,9 @@ for os in $OS; do
 				$root/configure --host="$arch-$vendor-$sys" --prefix="$archinstalldir" $configureflags
 			fi
 			if [ $build ]; then
+				if [ $currentconfigure ]; then
+					make clean || true
+				fi
 				make -j 4
 				make install
 				make check

--- a/configure.ac
+++ b/configure.ac
@@ -37,6 +37,10 @@ esac
 
 INCLUDE_PATHS="src src/openpa src/sfw/includes src/openpa/src"
 
+CFLAGS="$CFLAGS -fPIC"
+CPPFLAGS="$CPPFLAGS -fPIC"
+LDFLAGS="$LDFLAGS -fPIC"
+
 case "$target_os" in
 	mingw* | cygwin*)
 		OS=win
@@ -52,7 +56,7 @@ case "$target_os" in
 		OS=mac
 		AC_DEFINE([TARGET_MAC], [1], [ ])
 		INCLUDE_PATHS="$INCLUDE_PATHS src/sfw/includes/osx"
-		LDFLAGS="$LD_FLAGS -undefined suppress -flat_namespace"
+		LDFLAGS="$LDFLAGS -undefined suppress -flat_namespace"
 		;;
 	*)
 	AC_MSG_ERROR([$target_os is not supported!])

--- a/src/openpa/Makefile.am
+++ b/src/openpa/Makefile.am
@@ -16,8 +16,5 @@ libopenpa_la_SOURCES = \
 	src/opa_queue.c \
 	$(os_sources)
 
-if TARGET_LINUX
-	libopenpa_la_LDFLAGS = -static -fPIC
-else
-	libopenpa_la_LDFLAGS = -static
-endif
+libopenpa_la_CFLAGS = $(CFLAGS)
+libopenpa_la_LDFLAGS = $(LDFLAGS) -static

--- a/src/sfw/Makefile.am
+++ b/src/sfw/Makefile.am
@@ -48,13 +48,17 @@ common_sources = \
 	includes/SFWExport.h
 
 libsfw_la_SOURCES = $(common_sources) $(os_sources)
+
+libsfw_la_CFLAGS = $(CFLAGS)
 libsfw_la_CPPFLAGS = $(CPPFLAGS) $(includes)
 libsfw_la_LIBADD = $(top_builddir)/src/openpa/libopenpa.la
 
+libsfw_la_LDFLAGS = $(LDFLAGS) -no-undefined
+
 if TARGET_MAC
-	libsfw_la_LDFLAGS = $(LDFLAGS) -module -shared -no-undefined -framework CoreServices
+libsfw_la_LDFLAGS += -shared -framework CoreServices -framework CoreFoundation
 else
-	libsfw_la_LDFLAGS = $(LDFLAGS) -module -no-undefined
+libsfw_la_LDFLAGS += -module
 endif
 
 $(top_builddir)/build:

--- a/tests/test-console/Makefile.am
+++ b/tests/test-console/Makefile.am
@@ -2,7 +2,11 @@ check_PROGRAMS = test-console
 
 includes = $(addprefix -I$(top_srcdir)/, $(INCLUDE_PATHS))
 test_console_CPPFLAGS = $(CPPFLAGS) $(includes)
+
 test_console_LDFLAGS = $(LDFLAGS) -pthread
+if TARGET_MAC
+test_console_LDFLAGS += -framework CoreFoundation -framework CoreServices
+endif
 
 test_console_LDADD = $(top_builddir)/src/sfw/libsfw.la
 


### PR DESCRIPTION
I mistakenly indented the LDFLAGS lines in Makefile.am, which causes automake to copy those lines literally to the makefile instead of processing them properly, which means they were haha never actually executed, which means we were never linking properly with the frameworks.

The only reason this worked even though we did not link against any of the frameworks that have the symbols that we need is because openpa was 1) linked properly and 2) static and 3) we never directly use the missing symbols in our code, so at link time the linker did not pick up that it was missing symbol definitions (that were basically linked-deferred in openpa).

When running in Unity, Unity already has all the missing symbols loaded in the process space, which meant we never had issues finding those symbols. When running the native test-console, however, there's nothing loaded in the process so test-console would fail at runtime because it could not find kCF* symbols (CoreFoundation), a BIG HINT that linking was missing key frameworks.

Also fixed a typo in the build script, forced clean before building, and added -fPIC to generate position-independent code which is a Good Thing(tm)